### PR TITLE
Unwrap Optional model String

### DIFF
--- a/AndroidTool/Device.swift
+++ b/AndroidTool/Device.swift
@@ -48,6 +48,20 @@ class Device: NSObject {
             }
             }
     }
+    
+    func readableIdentifier() -> String {
+        if let modelString = model {
+            return modelString
+        } else if let nameString = name {
+            return nameString
+        } else if let manufacturerString = manufacturer {
+            return manufacturerString
+        } else if let serialString = serial {
+            return serialString
+        } else {
+            return "Android device"
+        }
+    }
 
 
 }

--- a/AndroidTool/DevicePickerViewController.swift
+++ b/AndroidTool/DevicePickerViewController.swift
@@ -43,7 +43,7 @@ class DevicePickerViewController: NSViewController, NSTableViewDelegate, NSTable
         
         ShellTasker(scriptFile: "installApkOnDevice").run(arguments: "\(serial) install -r \(apkPath)") { (output) -> Void in
 
-            Util().showNotification("App installed on \(device.model)", moreInfo: "\(output)", sound: true)
+            Util().showNotification("App installed on \(device.readableIdentifier())", moreInfo: "\(output)", sound: true)
             spinner.removeFromSuperview()
             self.dismissController(nil)
         }


### PR DESCRIPTION
Unwrap Optional String in a notification.

After installing an app the notification shows:
>App installed on Optional("Nexus 6")

This pull request fix it to:
>App installed on Nexus 6