### PR TITLE
Fix recording very short video issue

### DIFF
--- a/AndroidTool/DeviceViewController.swift
+++ b/AndroidTool/DeviceViewController.swift
@@ -71,6 +71,8 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         moreButton.enabled = false
         let restingButton = videoButton.image
         videoButton.image = NSImage(named: "stopButton")
+        videoButton.enabled = false
+        enableVideoButton()
         shellTasker = ShellTasker(scriptFile: "startRecordingForSerial")
         
         var scalePref = NSUserDefaults.standardUserDefaults().doubleForKey("scalePref")
@@ -95,7 +97,8 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
             self.videoButton.image = restingButton
             var postProcessTask = ShellTasker(scriptFile: "postProcessMovieForSerial")
             postProcessTask.run(arguments: [self.device.serial!], complete: { (output) -> Void in
-                Util().showNotification("Your recording is ready", moreInfo: "", sound: true)
+                let message = output.containsString("File not found") ? "Cannot record a video!" : "Your recording is ready"
+                Util().showNotification(message, moreInfo: "", sound: true)
                 self.stopProgressIndication()
             })
         }

--- a/AndroidTool/DeviceViewController.swift
+++ b/AndroidTool/DeviceViewController.swift
@@ -71,6 +71,8 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         moreButton.enabled = false
         let restingButton = videoButton.image
         videoButton.image = NSImage(named: "stopButton")
+        videoButton.enabled = false
+        enableVideoButton()
         shellTasker = ShellTasker(scriptFile: "startRecordingForSerial")
         shellTasker.run(arguments: device.serial!) { (output) -> Void in
             self.startProgressIndication()
@@ -79,9 +81,18 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
             self.videoButton.image = restingButton
             var postProcessTask = ShellTasker(scriptFile: "postProcessMovieForSerial")
             postProcessTask.run(arguments: self.device.serial!, complete: { (output) -> Void in
-                Util().showNotification("Your recording is ready", moreInfo: "", sound: true)
+                let message = output.containsString("File not found") ? "Cannot record a video!" : "Your recording is ready"
+                Util().showNotification(message, moreInfo: "", sound: true)
                 self.stopProgressIndication()
             })
+        }
+    }
+    
+    func enableVideoButton() {
+        let delayInSeconds = 1.0
+        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(delayInSeconds * Double(NSEC_PER_SEC)))
+        dispatch_after(time, dispatch_get_main_queue()) {
+            self.videoButton.enabled = true
         }
     }
     

--- a/AndroidTool/postProcessMovieForSerial.sh
+++ b/AndroidTool/postProcessMovieForSerial.sh
@@ -34,9 +34,9 @@ echo 'Converting...'
 
 if [ "${deviceName//[$'\t\r\n ']}" == "platina" ]
 then
-    resolution="280x280"
+resolution="280x280"
 else
-    resolution="320x320"
+resolution="320x320"
 fi
 
 $thisdir/ffmpeg -f rawvideo -vcodec rawvideo -s $resolution -pix_fmt rgb24 -r 10 -i screencapture.raw  -an -c:v libx264 -pix_fmt yuv420p $finalFileName.mp4
@@ -48,15 +48,22 @@ $thisdir/ffmpeg -i $finalFileName.mp4 $finalFileName.gif
 
 echo 'Cleaning up...'
 rm screencapture.raw
+echo 'Opening file...'
+open $finalFileName.mp4
+
 else # -- Phone ---
 echo 'copying from phone...'
 $adb -s $serial pull /sdcard/capture.mp4
-mv capture.mp4 $finalFileName.mp4
-$thisdir/ffmpeg -i $finalFileName.mp4 $finalFileName.gif
+    if [ ! -f capture.mp4 ]
+    then
+        echo 'File not found'
+    else
+        mv capture.mp4 $finalFileName.mp4
+        $thisdir/ffmpeg -i $finalFileName.mp4 $finalFileName.gif
 
-echo 'cleaning up'
-$adb -s $serial shell rm /sdcard/capture.mp4
+        echo 'cleaning up'
+        $adb -s $serial shell rm /sdcard/capture.mp4
+        echo 'Opening file...'
+        open $finalFileName.mp4
+    fi
 fi
-
-echo 'Opening file...'
-open $finalFileName.mp4

--- a/AndroidTool/postProcessMovieForSerial.sh
+++ b/AndroidTool/postProcessMovieForSerial.sh
@@ -48,15 +48,22 @@ $thisdir/ffmpeg -i $finalFileName.mp4 $finalFileName.gif
 
 echo 'Cleaning up...'
 rm screencapture.raw
+echo 'Opening file...'
+open $finalFileName.mp4
+
 else # -- Phone ---
 echo 'copying from phone...'
 $adb -s $serial pull /sdcard/capture.mp4
+if [ ! -f capture.mp4 ]
+then
+echo 'File not found'
+else
 mv capture.mp4 $finalFileName.mp4
 $thisdir/ffmpeg -i $finalFileName.mp4 $finalFileName.gif
 
 echo 'cleaning up'
 $adb -s $serial shell rm /sdcard/capture.mp4
-fi
-
 echo 'Opening file...'
 open $finalFileName.mp4
+fi
+fi

--- a/AndroidTool/startRecordingForSerial.sh
+++ b/AndroidTool/startRecordingForSerial.sh
@@ -21,11 +21,21 @@ then
     $adb -s $serial shell screenrecord --o raw-frames /sdcard/screencapture.raw
 else
     echo "Recording from phone..."
-    orientation=$(`$adb shell dumpsys input | grep 'SurfaceOrientation' | awk '{ print $2 }'`)
-    if [ "$orientation" = "0" ] || [ "$orientation" = "2" ]
+    orientation=`$adb shell dumpsys input -s $serial | grep 'SurfaceOrientation' | awk '{ print $2 }' | tr -d '\r'`
+    if [ $orientation == 0 ] || [ $orientation == 2 ]
     then
-        $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $height"x"$width /sdcard/capture.mp4 # > $1/reclog.txt
+        if [ $width -gt $height ]
+        then
+            $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $height"x"$width /sdcard/capture.mp4 # > $1/reclog.txt
+        else
+            $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $width"x"$height /sdcard/capture.mp4 # > $1/reclog.txt
+        fi
     else
-        $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $width"x"$height /sdcard/capture.mp4 # > $1/reclog.txt
+        if [ $height -gt $width ]
+        then
+            $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $height"x"$width /sdcard/capture.mp4 # > $1/reclog.txt
+        else
+            $adb -s $serial shell screenrecord --bit-rate $bitrate --verbose --size $width"x"$height /sdcard/capture.mp4 # > $1/reclog.txt
+        fi
     fi
 fi


### PR DESCRIPTION
Fix https://github.com/mortenjust/androidtool-mac/issues/20

Most of the time this happens because the adb command doesn't create a video file. And sometimes the video file is created but corrupted.
So 
* in the script, I added check for the file exists.
* in Swift, I disable the button for 1 second after starting recording.

Sound good?