### PR TITLE
Fix screenRecFolder var

### DIFF
--- a/AndroidTool/convertMovieFiletoGif.sh
+++ b/AndroidTool/convertMovieFiletoGif.sh
@@ -10,7 +10,7 @@ thisdir=$1
 inputFile=$3
 outputFile=$4
 scale=$5
-screenRecordingsFolder=$6
+screenRecFolder=$6
 
 ConvertFile(){
     $thisdir/ffmpeg -i $inputFile -vf scale=iw*$scale:ih*$scale $outputFile


### PR DESCRIPTION
After ticking the "Also create GIF" option within the settings I noticed no gif output alongside my .mov file.
Enabled the verbose terminal output and noticed the mkdir command was failing.

Resolves:
```
/Applications/AndroidTool.app/Contents/Resources/convertMovieFiletoGif.sh
mkdir: : No such file or directory
```