### PR TITLE
unwrap optional gifUrl

### DIFF
--- a/AndroidTool/DeviceViewController.swift
+++ b/AndroidTool/DeviceViewController.swift
@@ -318,8 +318,8 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         cameraButton.enabled = true
         
         let movPath = outputFileURL.path!
-        let gifUrl = outputFileURL.URLByDeletingPathExtension
-        let gifPath = "\(gifUrl?.path!).gif"
+        let gifUrl = outputFileURL.URLByDeletingPathExtension!
+        let gifPath = "\(gifUrl.path!).gif"
         let ffmpegPath = NSBundle.mainBundle().pathForResource("ffmpeg", ofType: "")!
         let scalePref = NSUserDefaults.standardUserDefaults().doubleForKey("scalePref")
         let args = [ffmpegPath, movPath, gifPath, "\(scalePref)", getFolderForScreenRecordings()]


### PR DESCRIPTION
Resolves the following error error when running `convertMovieFiletoGif.sh`

```
Optional("/Users/mriddle/Desktop/AndroidTool/iOS-recording-0614-154005").gif: No such file or directory
```

We're the ones in control of the file name and extension so we're guaranteed a path by deleting the extension.